### PR TITLE
Alignement produit

### DIFF
--- a/style.css
+++ b/style.css
@@ -80,14 +80,18 @@ img{
     
 }
 
-
+.img {
+    width: 15em;
+    text-align: center;
+}
 
 
 .produit1{
     margin-top: 25%;
     flex-direction:row;
     display: flex;
-   margin-left: 15%;
+    justify-content: center;
+    flex-wrap: wrap;
     
 
 


### PR DESCRIPTION
Voilà une manière simple de centrer les produits.

Les changements:

## Sur le parent (.produit):

- on supprime le margin-left.
- on applique justify-content: center = c'est la méthode flexbox pour center les éléments enfants.

## Sur les éléments enfants (classe .img):

- on applique text-align: center = cela centre le contenu (le texte, les images).
- on définit une largeur, en fonction de la largeur du titre. 15em va bien, cela permet d'afficher le titre.

Pour les petits écrans, on met flex-wrap sur le parent: cela permet un retour de ligne.